### PR TITLE
replacing the template logic - @for with (forEach) notation on both S…

### DIFF
--- a/ui/app/components/code/sqleditor/SqlEditor.html
+++ b/ui/app/components/code/sqleditor/SqlEditor.html
@@ -13,20 +13,15 @@
 		<div class="action-icon counter-icon generic-context-drop-menu data-base-fields-submenu" 
 			 style="cursor: pointer; border: none; display: flex; font-size: 13px; font-weight: bold;">
 			:: Fields <span class="menu-added-arrow" style="padding-top: 3px; margin-top: -11px;">⌄</span>
-			<ul class="submenu">
-				<li style="background: #f8f8f8 !important; cursor:auto;">
-					&nbsp;Fields in the table
+			<ul class="submenu" (forEach)="selectedTableFields">
+				<li each="item">
+					<div class="list-item-header">
+						<span class="field-type">
+							{item.type}
+						</span> 
+						{item.name}
+					</div>
 				</li>
-				@for(field in this.selectedTableFields)
-					<li>
-						<div class="list-item-header">
-							<span class="field-type">
-								{field.type}
-							</span> 
-							{field.name}
-						</div>
-					</li>
-				@endfor
 			</ul>
 		</div>
 

--- a/ui/app/components/code/sqleditor/SqlEditor.js
+++ b/ui/app/components/code/sqleditor/SqlEditor.js
@@ -54,6 +54,8 @@ export class SqlEditor extends ViewComponent {
 		
 		if(this.$parent.service.fieldsByTableMap[databasename.trim()])
 			this.selectedTableFields = this.$parent.service.fieldsByTableMap[databasename.trim()];
+		if (Array.isArray(this.selectedTableFields))
+			this.selectedTableFields = [{ name: 'Fields in the table', type: '' }, ...this.selectedTableFields];
 
 		const parseDbFilename = `${databasename.split('.duckdb.')[0]}.duckdb`;
 		this.database = `${this.dbpath}/${parseDbFilename}`;
@@ -76,8 +78,12 @@ export class SqlEditor extends ViewComponent {
 
 	setupEditorQuery(databaseName){
 		this.selectedTable = databaseName.split('.duckdb.')[1];
-		this.selectedTableFields = this.$parent.service.fieldsByTableMap[databaseName];
-		const fieldsString = this.selectedTableFields.value.map(({ name }) => name).join(',');
+		const selectedTableFields = this.$parent.service.fieldsByTableMap[databaseName];
+		const fieldsString = selectedTableFields.map(({ name }) => name).join(',');
+		
+		if (Array.isArray(selectedTableFields))
+			this.selectedTableFields = [{ name: 'Fields in the table', type: '' }, ...selectedTableFields];
+
 		const query = `SELECT ${fieldsString} FROM ${this.selectedTable} LIMIT 100`
 		this.setCode(AIResponseLinterUtil.formatSQL(query));
 

--- a/ui/app/components/parts/Header.html
+++ b/ui/app/components/parts/Header.html
@@ -32,27 +32,23 @@
 				</span>
 				<ul class="submenu">
 					<li style="background: #f8f8f8 !important; cursor:auto;">
-						<img 
-							onclick="component.getScheduleList()"
-							src="app/assets/imgs/refresh-svgrepo-com.svg" 
-							style="cursor: pointer;" width="16">
+						<img onclick="component.getScheduleList()" src="app/assets/imgs/refresh-svgrepo-com.svg" style="cursor: pointer;"
+							width="16">
 						&nbsp;Scheduled pipelines
 					</li>
-					@if(this.scheduledPipelines.length === 0)
-						<li>No Job scheduled</li>
-					@endif
-
-					@for(ppline in this.scheduledPipelines)
-					<li id="{ppline.id}">
-						<div class="list-item-header">
-							{JSON.parse(ppline.schedule_settings).ppline_label}
-							<div class="list-item-details">
-								<output><b>Setting:</b> {ppline.periodicity} {ppline.time} {ppline.type}</output>
-								<output><b>Last Run:</b> {ppline.last_run == null ? 'None' : ppline.last_run}</output>
-							</div>
-						</div>
+					<li style="padding: 0;">
+						<ul (forEach)="scheduledPipelines">
+							<li each="item">
+								<div class="list-item-header">
+									{item.pipelineLbl}
+									<div class="list-item-details">
+										<output><b>Setting:</b> {item.periodicity} {item.time} {item.type}</output>
+										<output><b>Last Run:</b> {item.lastRun}</output>
+									</div>
+								</div>
+							</li>
+						</ul>
 					</li>
-					@endfor
 				</ul>
 			</div>
 

--- a/ui/app/components/parts/Header.js
+++ b/ui/app/components/parts/Header.js
@@ -74,7 +74,9 @@ export class Header extends ViewComponent {
 	async getScheduleList(){
 		const scheduledPipelinesInitList = await WorkspaceService.getPipelineSchedules();
 		this.workspaceService.schedulePipelinesStore = scheduledPipelinesInitList.data;			
-		this.scheduledPipelines = scheduledPipelinesInitList || [];			
+		this.scheduledPipelines = (scheduledPipelinesInitList || []).map(itm => 
+			({ pipelineLbl: JSON.parse(itm.schedule_settings).ppline_label, ...itm, lastRun: itm.last_run == null ? 'None' : itm.last_run })
+		);			
 		this.scheduledPipelinesCount = scheduledPipelinesInitList.length || 0;
 	}
 
@@ -84,7 +86,9 @@ export class Header extends ViewComponent {
 
 		this.workspaceService.aiAgentNamespaceDetails = namespaceInitData.ai_agent_namespace_details;
 		this.workspaceService.schedulePipelinesStore = Object.values(namespaceInitData.schedules.data);			
-		this.scheduledPipelines = this.workspaceService.schedulePipelinesStore.value;			
+		this.scheduledPipelines = this.workspaceService.schedulePipelinesStore.value.map(itm =>
+			({ pipelineLbl: JSON.parse(itm.schedule_settings).ppline_label, ...itm, lastRun: itm.last_run == null ? 'None' : itm.last_run })
+		);
 		this.scheduledPipelinesCount = this.workspaceService.schedulePipelinesStore.value.length;
 		this.workspaceService.totalPipelines = namespaceInitData.total_pipelines;
 


### PR DESCRIPTION
This PR fixes `SqlEditor` and `Header` UI components  which has been using Still.js template logic, making it to fail  when it's deployed on Windows:

- replaced @for with (forEach) notation